### PR TITLE
Fix handling of lists of params

### DIFF
--- a/src/async_spotify/api/_api_request_maker.py
+++ b/src/async_spotify/api/_api_request_maker.py
@@ -197,8 +197,7 @@ class ApiRequestHandler:
             if not isinstance(query_params[key], List):
                 query_params[key] = [str(query_params[key])]
 
-            for value in query_params[key]:
-                return_params.append((key, str(value)))
+            return_params.append(key, ",".join([str(i) for i in query_params[key]]))
 
         return return_params
 


### PR DESCRIPTION
Send multiple values for one key as a comma-separated list.